### PR TITLE
feat: add compliance tests to terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,11 @@
 *tfstate*
 *.tfplan
 
+# Terraform-Compliance
+*.tfplan.json
+
 # Github Super Linter
 super-linter.log
+
+# Python venv
+.venv

--- a/README.md
+++ b/README.md
@@ -61,10 +61,28 @@ This includes deployment of the following resources:
 
 ## Run Deployment
 
-Navigate to `deployment\terraform\aml`
+Navigate to `deployment/terraform/aml`
 
 - Run terraform init
 - Run terraform plan
 - Run terraform apply
 
 > You will need to provide values for `project_code` and `env_code`. Value for `location` is set to `West US 2` and `enable_private_link` is set to `true`.
+
+## Run Terraform Compliance Tests
+
+[Terraform Compliance](https://terraform-compliance.com/) is a python based framework used to test against terraform execution plan
+with the given scenarios (see folder `deployment/terraform/features`). You need Python 3.x to run it (see [installation docs](https://terraform-compliance.com/pages/installation/))
+
+Execute the following steps to run the tests
+
+```bash
+cd deployment/terraform/aml
+terraform init
+terraform plan -out=plan.tfplan -var 'project_code=dp333' -var 'env_code=dev' -var 'location=West Europe' -var 'enable_private_endpoints=true'
+terraform-compliance -p plan.tfplan -f ../features/
+```
+
+and review the output.
+
+> For the current scenario implementation the location to be used has to be `West Europe`

--- a/deployment/terraform/common/bastion/main.tf
+++ b/deployment/terraform/common/bastion/main.tf
@@ -57,7 +57,7 @@ resource "azurerm_network_security_group" "this" {
       protocol                   = security_rule.value.protocol
       source_port_range          = security_rule.value.source_port_range
       source_address_prefix      = security_rule.value.source_address_prefix
-      destination_port_ranges     = security_rule.value.destination_port_ranges
+      destination_port_ranges    = security_rule.value.destination_port_ranges
       destination_address_prefix = security_rule.value.destination_address_prefix
     }
   }

--- a/deployment/terraform/features/acr.feature
+++ b/deployment/terraform/features/acr.feature
@@ -1,0 +1,19 @@
+Feature: Azure Container Registry Compliance
+
+  This is an example how an compliance test for the current
+  Azur Container Registry configuration might look like
+
+  Scenario: Ensure Standard SKU is installed
+    Given I have azurerm_container_registry defined
+    Then it must contain SKU
+    And its value must be Standard
+
+  Scenario: Ensure Location is in West Europe
+    Given I have azurerm_container_registry defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure that admin access is enabled
+    Given I have azurerm_container_registry defined
+    When it contains admin_enabled
+    Then its value must be true

--- a/deployment/terraform/features/appinssights.feature
+++ b/deployment/terraform/features/appinssights.feature
@@ -1,0 +1,14 @@
+Feature: Application Insights Compliance
+
+  This is an example how an compliance test for the current
+  Application Insights configuration might look like
+
+  Scenario: Ensure Location is in West Europe
+    Given I have azurerm_application_insights defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure that type is web
+    Given I have azurerm_application_insights defined
+    Then it must contain application_type
+    Then its value must be web

--- a/deployment/terraform/features/bastion.feature
+++ b/deployment/terraform/features/bastion.feature
@@ -1,0 +1,19 @@
+Feature: Bastion Compliance
+
+  This is an example how an compliance test for the current
+  Azure Bastion configuration might look like
+
+  Scenario: Ensure Bastion Location is in West Europe
+    Given I have azurerm_bastion_host defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure Bastion has a public static ip
+    Given I have azurerm_public_ip defined
+    Then it must contain allocation_method
+    And its value must be Static
+
+  Scenario: Ensure Bastion is using standard SKU
+    Given I have azurerm_public_ip defined
+    Then it must contain sku
+    And its value must be Standard

--- a/deployment/terraform/features/dsvm.feature
+++ b/deployment/terraform/features/dsvm.feature
@@ -1,0 +1,27 @@
+Feature: DSVM Compliance
+
+  This is an example how an compliance test for the current
+  Azure Data Science Virtual Machine configuration might look like
+
+  Scenario: Ensure DSVM Location is in West Europe
+    Given I have azurerm_virtual_machine defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario Outline: Ensure DSVM image is using DSVM Build 2019 by Microsoft
+    Given I have azurerm_virtual_machine defined
+    When it contains storage_image_reference
+    Then it must contain <key>
+    And its value must be <value>
+
+    Examples:
+      | key       | value          |
+      | publisher | microsoft-dsvm |
+      | offer     | dsvm-win-2019  |
+      | sku       | server-2019    |
+      | version   | latest         |
+
+  Scenario: Ensure that identity is system assigned
+    Given I have azurerm_virtual_machine defined
+    When it has identity
+    Then its type must be SystemAssigned

--- a/deployment/terraform/features/keyvault.feature
+++ b/deployment/terraform/features/keyvault.feature
@@ -1,0 +1,48 @@
+Feature: Key Vault Compliance
+
+  This is an example how an compliance test for the current
+  Azure Key Vault configuration might look like
+
+  Scenario: Ensure Standard SKU is installed
+    Given I have azurerm_key_vault defined
+    Then it must contain sku_name
+    And its value must be Standard
+
+  Scenario: Ensure Location is in West Europe
+    Given I have azurerm_key_vault defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure that purge protection is enabled
+    Given I have azurerm_key_vault defined
+    When it contains purge_protection_enabled
+    Then its value must be true
+
+  Scenario: Ensure that key permissions are correct
+    Given I have azurerm_key_vault defined
+    Then it must contain access_policy
+    Then it must contain key_permissions
+    Then its value must contain get
+    And its value must contain create
+    And its value must contain delete
+    And its value must contain list
+    And its value must contain restore
+    And its value must contain recover
+    And its value must contain unwrapkey
+    And its value must contain wrapkey
+    And its value must contain purge
+    And its value must contain encrypt
+    And its value must contain decrypt
+    And its value must contain sign
+    And its value must contain verify
+    And its value must contain update
+
+
+  Scenario: Ensure that secret permissions are correct
+    Given I have azurerm_key_vault defined
+    Then it must contain access_policy
+    Then it must contain secret_permissions
+    Then its value must contain set
+    And its value must contain get
+    And its value must contain delete
+    And its value must contain list

--- a/deployment/terraform/features/storage.feature
+++ b/deployment/terraform/features/storage.feature
@@ -1,0 +1,29 @@
+Feature: Azure Storage Compliance
+
+  This is an example how an compliance test for the current
+  Azure Storage configuration might look like
+
+  Scenario: Ensure Location is in West Europe
+    Given I have azurerm_storage_account defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure minimum TLS version is set to 1.2
+    Given I have azurerm_storage_account_network_rules defined
+    Then it must contain min_tls_version
+    And its value must be TLS1_2
+
+  Scenario: Ensure that identity is system assigned
+    Given I have azurerm_storage_account_network_rules defined
+    When it has identity
+    Then its type must be SystemAssigned
+
+  Scenario: Ensure Network Rules are set and Deny access
+    Given I have azurerm_storage_account_network_rules defined
+    Then it must contain default_action
+    And its value must be Deny
+
+  Scenario: Ensure Network Rules are set and bypass Azure Services
+    Given I have azurerm_storage_account_network_rules defined
+    Then it must contain bypass
+    And its value must be AzureServices

--- a/deployment/terraform/features/vnet.feature
+++ b/deployment/terraform/features/vnet.feature
@@ -1,0 +1,32 @@
+Feature: VNet Compliance
+
+  This is an example how an compliance test for the current
+  Azure Virtual Network configuration might look like
+
+  Scenario: Ensure Virtual Network address space is correct
+    Given I have azurerm_virtual_network defined
+    Then it must contain address_space
+    And its value must be 10.0.0.0/20
+
+  Scenario: Ensure VNet Location is in West Europe
+    Given I have azurerm_virtual_network defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure multiple subnets
+    Given I have azurerm_subnet defined
+    When I count them
+    Then its value must be 3
+
+  Scenario Outline: Ensure address space is correctly defined in Subnets
+    Given I have azurerm_subnet defined
+    When its name is <subnet>
+    Then it must contain address_prefixes
+    And its value must be <addrprefix>
+
+    Examples:
+      | subnet             | addrprefix  |
+      | AzureBastionSubnet | 10.0.0.0/27 |
+      | AMLSubnet          | 10.0.1.0/24 |
+      | DSVMSubnet         | 10.0.2.0/24 |
+

--- a/deployment/terraform/features/workspace.feature
+++ b/deployment/terraform/features/workspace.feature
@@ -1,0 +1,14 @@
+Feature: Azure Machine learning Workspace Compliance
+
+  This is an example how an compliance test for the current
+  Azure Machine Learning Workspace configuration might look like
+
+  Scenario: Ensure Location is in West Europe
+    Given I have azurerm_machine_learning_workspace defined
+    Then it must contain location
+    And its value must be westeurope
+
+  Scenario: Ensure that identity is system assigned
+    Given I have azurerm_machine_learning_workspace defined
+    When it has identity
+    Then its type must be SystemAssigned


### PR DESCRIPTION
Compliance testing the terraform execution plan against a set of
given scenarios to check the validity of the current parameters.

These tests are samples to demonstrate how this can be achieved and
are generic and neither complete.

Additional changes

- Modified .gitignore to value python virtual envs as well as
terraform compliance plans itself
- Modified README to include steps for testing